### PR TITLE
Document progress on Secret Discoveries

### DIFF
--- a/locations/get-secret-discoveries-from-wiki.sh
+++ b/locations/get-secret-discoveries-from-wiki.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+CATEGORY=Secret_Discoveries
+LIST_ALL_URL="https://wynncraft.fandom.com/api.php?action=query&format=json&list=categorymembers&meta=&rawcontinue=1&cmtitle=Category%3A${CATEGORY}&cmprop=ids%7Ctitle&cmlimit=183&cmdir=newer"
+curl -s "$LIST_ALL_URL" | jq '.query.categorymembers[] | .title,.pageid'  > ${CATEGORY}-pages.txt
+
+function get_infobox_json() {
+  local pageid=$1
+  local output_dir=$2
+  local base_name=$3
+
+  local raw_file=${output_dir}/tmp/${base_name}.raw.json
+  local wikitext_file=${output_dir}/tmp/${base_name}.wikitext.json
+  local infobox_file=${output_dir}/tmp/${base_name}.infobox.json
+  local output_file=${output_dir}/${base_name}.json
+
+  # Download json description of the wiki page
+  curl -s "https://wynncraft.fandom.com/api.php?action=query&format=json&prop=revisions&pageids=${pageid}&rvprop=content&rvslots=main" > ${raw_file}
+
+  # Extract the wiki text from the json
+  jq '.query.pages[] | .revisions[] | .slots.main["*"]' ${raw_file} > ${wikitext_file}
+
+  # Extract the infobox from the wiki text, and convert it to a properties file
+  # The complex first expression will allow matching for one level of nested "{{ .. }}"
+  sed -E -e 's/^.*{\{Infobox\/Town((([^{}][^{}]*)(\{\{[^}][^}]*\}\})?)*)\}\}.*$/\1/' -e 's/\\n$//g' -e 's/ *\\n\| */\n/g' -e 's/^\n//g' -e 's/ *$//g'  -e '/^$/d'  -e 's/ *= */=/g' < ${wikitext_file} > ${infobox_file}
+
+  # Convert the properties file to json
+  jq -R -s 'split("\n") | map(select(length > 0)) | map(select(startswith("#") | not)) | map(split("=")) | map({(.[0]): .[1:] | join("=")}) | add' < ${infobox_file} > ${output_file}
+}
+
+mkdir -p $CATEGORY/tmp
+cat ${CATEGORY}-pages.txt | while read -r title; do
+    read pageid
+    filename=$(tr ' ' '_' <<< $title | tr -d '"')
+    echo Creating $filename.json from pageid $pageid
+    get_infobox_json $pageid ${CATEGORY} $filename
+done
+rm ${CATEGORY}-pages.txt

--- a/reference/2022-12-13_10.30.52-discoveries.csv
+++ b/reference/2022-12-13_10.30.52-discoveries.csv
@@ -1,0 +1,106 @@
+level,type,name
+1,secret,A Hero's Origin
+1,secret,Far From the Roots
+1,secret,Ragni's Secret Library
+1,secret,Watchmen
+5,secret,Bak'al's Destruction 1
+5,secret,Bak'al's Destruction 2
+5,secret,Bak'al's Destruction 3
+5,secret,Boulder Breaker
+5,secret,Historical Maltic
+5,secret,Ruins of Detlas
+5,secret,Water of the Past
+10,secret,Beneath the Roots
+10,secret,Somewhere In Between
+10,secret,Timeless Ruin
+15,secret,Crate Crane
+20,secret,Mining Operation
+20,secret,Wynn Plains Monument
+25,secret,Boulder Pit
+25,secret,Quicksand
+25,secret,Temple Ruin
+25,secret,Temple of Swords
+30,secret,Desert Royal Residence
+30,secret,Rymek Thief
+30,secret,Totem Pole
+30,secret,Wrecking Ball
+35,secret,Abandoned Excavations
+35,secret,At the Edge of Decay
+35,secret,Explorer's Corruption Study
+35,secret,Frozen Cave Hideout
+35,secret,Llevigar's Secret Library
+35,secret,Spider Ruins
+35,secret,Unstable Experiments
+35,secret,Wolf Temple
+40,secret,A Deathly Warning
+40,secret,Llevigar's Last Hope
+40,secret,Lusuco's Secret Library
+40,secret,Nilrem's Sealed Letter
+40,secret,Pottery Wheel
+40,secret,Teachings of Old
+40,secret,The Lone Telescope
+40,secret,The Twains' Downfall
+40,secret,Torn in Twain
+45,secret,Decaying Mountains
+45,secret,Empty Vaults
+45,secret,Harmless Worms
+45,secret,Lost Farmers
+45,secret,Shadowy Dealings
+45,secret,Shrouded Lives
+45,secret,The Bane of Gavel
+55,secret,Parasite Cocoon
+60,secret,A Dividing Force
+60,secret,Summoner's Fate
+64,secret,"Headless, Not Homeless"
+65,secret,Birth of Efilim
+65,secret,Fracture in Reality
+65,secret,Hallowed Ground
+65,secret,Light Mushrooms
+65,secret,Sealed Away
+65,secret,Temple of Light
+70,secret,Gavel Excavation
+70,secret,Gylia Watch Library
+70,secret,Gylia's Cataclysm
+70,secret,Mark of the Meteors
+70,secret,Messengers From Beyond
+70,secret,Ne du Valeos du Ellach
+70,secret,The Ancient Ones
+70,secret,The Grand Archive
+70,secret,The Great Barrier
+70,secret,The Heart of the Decay
+70,secret,The Talor Crypt
+70,secret,Ways of the Wicked
+80,secret,Canyon Housing
+80,secret,Cosmic Crystals
+80,secret,Cracked Canyon
+80,secret,Loot of the Lost
+80,secret,Relos' Secret Library
+80,secret,Thanos Armory
+80,secret,The Broken Protector
+85,secret,Chained Goliaths
+85,secret,Cultural Artefact
+85,secret,Lost Avos City
+85,secret,Maex Black Market
+85,secret,Sealed in Ice
+85,secret,Subterranean Creation
+85,secret,The Doguns' Defeat
+85,secret,Tomb of the Founders
+90,secret,Ahmsord's Origins
+90,secret,Colossal Ruins
+90,secret,Desolate Temples
+90,secret,Far Above the Clouds
+90,secret,Necklace Chamber
+90,secret,Otherworldly Origins
+90,secret,Rulers of the Skies
+95,secret,The Fallen Protector
+95,secret,The Lonely Abyss
+100,secret,A Monument of Hope
+100,secret,A Wynnic Excavation
+100,secret,Fate of the Olm
+100,secret,Mining Cessation
+100,secret,Otherworldly Occurrence
+100,secret,Silent Expanse's Secret
+100,secret,Space Between Realities
+100,secret,The Final Moments
+100,secret,The Forest has Eyes
+100,secret,Toxic Bounce


### PR DESCRIPTION
This PR contains the groundwork for generating proper data for the Reference repo regarding secret discoveries. It includes an almost-finished script that scrapes the wiki for infobox data on Secret Discoveries, parses those and converts them to json.

During the development of this script I noted the sorry shape of the data on the wiki. :-( It might not be usable to us, but the script took quite a lot of effort to develop, and it can be useful in scraping other infobox data of the wiki as well, so I'd like to keep it.

The second part of this PR is a high-quality CSV file from @coehlrich. It contains the name and level for all secret discoveries as found in-game as of today. This data was downloaded from https://discord.com/channels/942560349817831435/942564848330498048/1051985655267348500, and was generated by using this mod:
https://gist.github.com/coehlrich/d0deb3dd7a2686dc34a8816bf1907fb0 on coehlrich's account, which has all secret discoveries unlocked.

I will stop working with secret discoveries data for now, but wanted to document my latest results.